### PR TITLE
more bone name variations

### DIFF
--- a/immersive_scaler/operations.py
+++ b/immersive_scaler/operations.py
@@ -74,21 +74,21 @@ def hide_reset():
 
 
 bone_names = {
-    "right_shoulder": ["Right shoulder", "Shoulder.R", "R_Shoulder", "Shoulder_R"],
+    "right_shoulder": ["Right shoulder", "Shoulder.R", "R_Shoulder", "Shoulder_R", "RightShoulder"],
     "right_arm": ["Right arm", "Arm.R", "R_Arm", "r_arm", "UpperArm.R", "Arm_R", "RightUpperArm", "UpperArm_R"],
     "right_elbow": ["Right elbow", "Elbow.R", "R_elbow", "Elbow.r", "r_elbow", "R_Elbow", "LowerArm.R", "RightLowerArm", "LowerArm_R"],
-    "right_wrist": ["Right wrist", "Wrist.R", "R_wrist", "Wrist.r", "r_wrist", "R_Wrist", "Hand_R"],
-    "right_leg": ["Right leg", "Leg.R", "R_Leg", "R_leg", "leg.r", "UpperLeg.R", "Leg_R", "Thigh_R", "UpperLeg_R"],
-    "right_knee": ["Right knee", "Knee.R", "R_Knee", "R_knee", "knee.r", "LowerLeg.R", "Calf_R", "LowerLeg_R"],
-    "right_ankle": ["Right ankle", "Ankle.R", "R_Ankle", "R_ankle", "ankle.r", "Right Foot", "Foot.R", "Ankle_R"],
+    "right_wrist": ["Right wrist", "Wrist.R", "R_wrist", "Wrist.r", "r_wrist", "R_Wrist", "Hand_R", "RightHand"],
+    "right_leg": ["Right leg", "Leg.R", "R_Leg", "R_leg", "leg.r", "UpperLeg.R", "Leg_R", "Thigh_R", "UpperLeg_R", "RightUpperLeg"],
+    "right_knee": ["Right knee", "Knee.R", "R_Knee", "R_knee", "knee.r", "LowerLeg.R", "Calf_R", "LowerLeg_R", "RightLowerLeg"],
+    "right_ankle": ["Right ankle", "Ankle.R", "R_Ankle", "R_ankle", "ankle.r", "Right Foot", "Foot.R", "Ankle_R", "RightFoot"],
 
-    "left_shoulder": ["Left shoulder", "Shoulder.L", "L_Shoulder", "Shoulder_L"],
+    "left_shoulder": ["Left shoulder", "Shoulder.L", "L_Shoulder", "Shoulder_L", "LeftShoulder"],
     "left_arm": ["Left arm", "Arm.L", "L_Arm", "l_arm", "UpperArm.L", "Arm_L", "LeftUpperArm", "UpperArm_L"],
     "left_elbow": ["Left elbow", "Elbow.L", "L_elbow", "Elbow.l", "l_elbow", "L_Elbow", "LowerArm.L", "LeftLowerArm", "LowerArm_L"],
-    "left_wrist": ["Left wrist", "Wrist.L", "L_wrist", "Wrist.l", "l_wrist", "L_Wrist", "Hand_L"],
-    "left_leg": ["Left leg", "Leg.L", "L_Leg", "L_leg", "leg.l", "UpperLeg.L", "Leg_L", "Thigh_L", "UpperLeg_L"],
-    "left_knee": ["Left knee", "Knee.L", "L_Knee", "L_knee", "knee.l", "LowerLeg.L", "Calf_L", "LowerLeg_L"],
-    "left_ankle": ["Left ankle", "Ankle.L", "L_Ankle", "L_ankle", "ankle.l", "Left Foot", "Foot.L", "Ankle_L"]
+    "left_wrist": ["Left wrist", "Wrist.L", "L_wrist", "Wrist.l", "l_wrist", "L_Wrist", "Hand_L", "LeftHand"],
+    "left_leg": ["Left leg", "Leg.L", "L_Leg", "L_leg", "leg.l", "UpperLeg.L", "Leg_L", "Thigh_L", "UpperLeg_L", "LeftUpperLeg"],
+    "left_knee": ["Left knee", "Knee.L", "L_Knee", "L_knee", "knee.l", "LowerLeg.L", "Calf_L", "LowerLeg_L", "LeftLowerLeg"],
+    "left_ankle": ["Left ankle", "Ankle.L", "L_Ankle", "L_ankle", "ankle.l", "Left Foot", "Foot.L", "Ankle_L", "LeftFoot"]
 }
 
 def get_bone(name, arm):


### PR DESCRIPTION
Added so I could use immersive scaler on Mint, Rusk, and Amanatsu from Booth without errors.

#4 would be very useful, but in the meantime a proper error message for when a bone is missing would be nice.