### PR TITLE
More genericized bone name matching

### DIFF
--- a/immersive_scaler/operations.py
+++ b/immersive_scaler/operations.py
@@ -74,28 +74,29 @@ def hide_reset():
 
 
 bone_names = {
-    "right_shoulder": ["Right shoulder", "Shoulder.R", "R_Shoulder", "Shoulder_R", "RightShoulder"],
-    "right_arm": ["Right arm", "Arm.R", "R_Arm", "r_arm", "UpperArm.R", "Arm_R", "RightUpperArm", "UpperArm_R"],
-    "right_elbow": ["Right elbow", "Elbow.R", "R_elbow", "Elbow.r", "r_elbow", "R_Elbow", "LowerArm.R", "RightLowerArm", "LowerArm_R"],
-    "right_wrist": ["Right wrist", "Wrist.R", "R_wrist", "Wrist.r", "r_wrist", "R_Wrist", "Hand_R", "RightHand"],
-    "right_leg": ["Right leg", "Leg.R", "R_Leg", "R_leg", "leg.r", "UpperLeg.R", "Leg_R", "Thigh_R", "UpperLeg_R", "RightUpperLeg"],
-    "right_knee": ["Right knee", "Knee.R", "R_Knee", "R_knee", "knee.r", "LowerLeg.R", "Calf_R", "LowerLeg_R", "RightLowerLeg"],
-    "right_ankle": ["Right ankle", "Ankle.R", "R_Ankle", "R_ankle", "ankle.r", "Right Foot", "Foot.R", "Ankle_R", "RightFoot"],
+    "right_shoulder": ["rightshoulder", "shoulderr", "rshoulder"],
+    "right_arm": ["rightarm", "armr", "rarm", "upperarmr", "rightupperarm"],
+    "right_elbow": ["rightelbow", "elbowr", "relbow", "lowerarmr", "rightlowerarm", "lowerarmr"],
+    "right_wrist": ["rightwrist", "wristr", "rwrist", "handr", "righthand"],
+    "right_leg": ["rightleg", "legr", "rleg", "upperlegr", "thighr","rightupperleg"],
+    "right_knee": ["rightknee", "kneer", "rknee", "lowerlegr", "calfr", "rightlowerleg"],
+    "right_ankle": ["rightankle", "ankler", "rankle", "rightfoot", "footr", "rightfoot"],
 
-    "left_shoulder": ["Left shoulder", "Shoulder.L", "L_Shoulder", "Shoulder_L", "LeftShoulder"],
-    "left_arm": ["Left arm", "Arm.L", "L_Arm", "l_arm", "UpperArm.L", "Arm_L", "LeftUpperArm", "UpperArm_L"],
-    "left_elbow": ["Left elbow", "Elbow.L", "L_elbow", "Elbow.l", "l_elbow", "L_Elbow", "LowerArm.L", "LeftLowerArm", "LowerArm_L"],
-    "left_wrist": ["Left wrist", "Wrist.L", "L_wrist", "Wrist.l", "l_wrist", "L_Wrist", "Hand_L", "LeftHand"],
-    "left_leg": ["Left leg", "Leg.L", "L_Leg", "L_leg", "leg.l", "UpperLeg.L", "Leg_L", "Thigh_L", "UpperLeg_L", "LeftUpperLeg"],
-    "left_knee": ["Left knee", "Knee.L", "L_Knee", "L_knee", "knee.l", "LowerLeg.L", "Calf_L", "LowerLeg_L", "LeftLowerLeg"],
-    "left_ankle": ["Left ankle", "Ankle.L", "L_Ankle", "L_ankle", "ankle.l", "Left Foot", "Foot.L", "Ankle_L", "LeftFoot"]
+    "left_shoulder": ["leftshoulder", "shoulderl", "rshoulder"],
+    "left_arm": ["leftarm", "arml", "rarm", "upperarml", "leftupperarm"],
+    "left_elbow": ["leftelbow", "elbowl", "relbow", "lowerarml", "leftlowerarm", "lowerarml"],
+    "left_wrist": ["leftwrist", "wristl", "rwrist", "handl", "lefthand"],
+    "left_leg": ["leftleg", "legl", "rleg", "upperlegl", "thighl","leftupperleg"],
+    "left_knee": ["leftknee", "kneel", "rknee", "lowerlegl", "calfl", "leftlowerleg"],
+    "left_ankle": ["leftankle", "anklel", "rankle", "leftfoot", "footl", "leftfoot"],
 }
 
 def get_bone(name, arm):
     name_list = bone_names[name]
+    bone_lookup = dict([(bone.name.lower().translate(dict.fromkeys(map(ord, u" _."))), bone) for bone in arm.pose.bones])
     for n in name_list:
-        if n in arm.pose.bones:
-            return arm.pose.bones[n]
+        if n in bone_lookup:
+            return bone_lookup[n]
     return arm.pose.bones[name]
 
 def get_lowest_point():


### PR DESCRIPTION
This change matches for any bone name variation regardless of capitalization or the presence/absence of ' ', '_' and '.' characters.